### PR TITLE
feat: backport 19211 and part of 18506

### DIFF
--- a/LeanOA.lean
+++ b/LeanOA.lean
@@ -1,3 +1,5 @@
 import LeanOA.CFCRange
+import LeanOA.ForMathlib.Analysis.CStarAlgebra.SpecialFunctions.PosPart
+import LeanOA.ForMathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.PosPart
 import LeanOA.ForMathlib.Topology.Algebra.NonUnitalStarAlgebra
 import LeanOA.ForMathlib.Topology.Algebra.NonUnitalSubalgebra

--- a/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2024 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import LeanOA.ForMathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.PosPart
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+
+/-! # C⋆-algebraic facts about `a⁺` and `a⁻`.
+
+[PR #18056](https://github.com/leanprover-community/mathlib4/pull/18506)
+-/
+
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+namespace CStarAlgebra
+
+section SpanNonneg
+
+open Submodule
+
+/-- A C⋆-algebra is spanned by nonnegative elements of norm at most `r` -/
+lemma span_nonneg_inter_closedBall {r : ℝ} (hr : 0 < r) :
+    span ℂ ({x : A | 0 ≤ x} ∩ Metric.closedBall 0 r) = ⊤ := by
+  rw [eq_top_iff, ← span_nonneg, span_le]
+  intro x hx
+  obtain (rfl | hx_pos) := eq_zero_or_norm_pos x
+  · exact zero_mem _
+  · suffices (r * ‖x‖⁻¹ : ℂ)⁻¹ • ((r * ‖x‖⁻¹ : ℂ) • x) = x by
+      rw [← this]
+      refine smul_mem _ _ (subset_span <| Set.mem_inter ?_ ?_)
+      · norm_cast
+        exact smul_nonneg (by positivity) hx
+      · simp [mul_smul, norm_smul, abs_of_pos hr, inv_mul_cancel₀ hx_pos.ne']
+    apply inv_smul_smul₀
+    norm_cast
+    positivity
+
+/-- A C⋆-algebra is spanned by nonnegative elements of norm less than `r`. -/
+lemma span_nonneg_inter_ball {r : ℝ} (hr : 0 < r) :
+    span ℂ ({x : A | 0 ≤ x} ∩ Metric.ball 0 r) = ⊤ := by
+  rw [eq_top_iff, ← span_nonneg_inter_closedBall (half_pos hr)]
+  gcongr
+  exact Metric.closedBall_subset_ball <| half_lt_self hr
+
+/-- A C⋆-algebra is spanned by nonnegative contractions. -/
+lemma span_nonneg_inter_unitClosedBall :
+    span ℂ ({x : A | 0 ≤ x} ∩ Metric.closedBall 0 1) = ⊤ :=
+  span_nonneg_inter_closedBall zero_lt_one
+
+/-- A C⋆-algebra is spanned by nonnegative strict contractions. -/
+lemma span_nonneg_inter_unitBall :
+    span ℂ ({x : A | 0 ≤ x} ∩ Metric.ball 0 1) = ⊤ :=
+  span_nonneg_inter_ball zero_lt_one
+
+end SpanNonneg
+
+end CStarAlgebra

--- a/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -4,18 +4,56 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import LeanOA.ForMathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.PosPart
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric
 
 /-! # C⋆-algebraic facts about `a⁺` and `a⁻`.
 
 [PR #18056](https://github.com/leanprover-community/mathlib4/pull/18506)
 -/
 
-variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+variable {A : Type*}
 
 namespace CStarAlgebra
 
+section Norm
+
+variable [NonUnitalNormedRing A] [NormedSpace ℝ A] [IsScalarTower ℝ A A]
+variable [SMulCommClass ℝ A A] [RegularNormedAlgebra ℝ A] [StarRing A] [CompleteSpace A]
+variable [NonUnitalIsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint]
+
+@[simp]
+lemma norm_posPart_le (a : A) : ‖a⁺‖ ≤ ‖a‖ := by
+  refine norm_cfcₙ_le fun x hx ↦ ?_
+  obtain (h | h) := le_or_lt x 0
+  · simp [_root_.posPart_def, max_eq_right h]
+  · simp only [_root_.posPart_def, max_eq_left h.le]
+    rw [Unitization.quasispectrum_eq_spectrum_inr] at hx
+    rw [← Unitization.norm_inr (𝕜 := ℝ) a]
+    exact spectrum.norm_le_norm_of_mem hx
+
+@[simp]
+lemma norm_negPart_le (a : A) : ‖a⁻‖ ≤ ‖a‖ := by
+  simpa [CFC.negPart_neg] using norm_posPart_le (-a)
+
+lemma _root_.IsSelfAdjoint.norm_eq_max_norm_posPart_negPart (a : A) (ha : IsSelfAdjoint a := by cfc_tac) :
+    ‖a‖ = max ‖a⁺‖ ‖a⁻‖ := by
+  refine le_antisymm ?_ <| max_le (norm_posPart_le a) (norm_negPart_le a)
+  conv_lhs => rw [← cfcₙ_id' ℝ a]
+  rw [norm_cfcₙ_le_iff ..]
+  intro x hx
+  obtain (hx' | hx') := le_total 0 x
+  · apply le_max_of_le_left
+    refine le_of_eq_of_le ?_ <| norm_apply_le_norm_cfcₙ _ a hx
+    rw [posPart_eq_self.mpr hx']
+  · apply le_max_of_le_right
+    refine le_of_eq_of_le ?_ <| norm_apply_le_norm_cfcₙ _ a hx
+    rw [negPart_eq_neg.mpr hx', norm_neg]
+
+end Norm
+
 section SpanNonneg
+
+variable [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
 open Submodule
 

--- a/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/LeanOA/ForMathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -8,7 +8,7 @@ import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric
 
 /-! # C⋆-algebraic facts about `a⁺` and `a⁻`.
 
-[PR #18056](https://github.com/leanprover-community/mathlib4/pull/18506)
+[PR #18056](https://github.com/leanprover-community/mathlib4/pull/18506) upstreams the material about `span` to Mathlib.
 -/
 
 variable {A : Type*}

--- a/LeanOA/ForMathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
+++ b/LeanOA/ForMathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
@@ -1,0 +1,178 @@
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.PosPart
+
+/-! # Expand API for `CFC.posPart`
+
+[PR #19221](https://github.com/leanprover-community/mathlib4/pull/19221/) for most of it.
+[PR #18056](https://github.com/leanprover-community/mathlib4/pull/18506) for the `span` results.
+
+-/
+
+open scoped NNReal
+
+section NonUnital
+
+variable {A : Type*} [NonUnitalRing A] [Module ℝ A] [SMulCommClass ℝ A A] [IsScalarTower ℝ A A]
+variable [StarRing A] [TopologicalSpace A]
+variable [NonUnitalContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
+
+namespace CFC
+
+@[simp]
+lemma posPart_zero : (0 : A)⁺ = 0 := by simp [posPart_def]
+
+@[simp]
+lemma negPart_zero : (0 : A)⁻ = 0 := by simp [negPart_def]
+
+section SMul
+
+variable [StarModule ℝ A]
+variable [UniqueNonUnitalContinuousFunctionalCalculus ℝ A]
+
+@[simp]
+lemma posPart_smul {r : ℝ≥0} {a : A} : (r • a)⁺ = r • a⁺ := by
+  by_cases ha : IsSelfAdjoint a
+  · simp only [CFC.posPart_def, NNReal.smul_def]
+    rw [← cfcₙ_comp_smul .., ← cfcₙ_smul ..]
+    refine cfcₙ_congr fun x hx ↦ ?_
+    simp [_root_.posPart_def, mul_max_of_nonneg]
+  · obtain (rfl | hr) := eq_or_ne r 0
+    · simp
+    · have := (not_iff_not.mpr <| (IsSelfAdjoint.all r).smul_iff hr.isUnit (x := a)) |>.mpr ha
+      simp [CFC.posPart_def, cfcₙ_apply_of_not_predicate a ha,
+        cfcₙ_apply_of_not_predicate _ this]
+
+@[simp]
+lemma negPart_smul {r : ℝ≥0} {a : A} : (r • a)⁻ = r • a⁻ := by
+  simpa using posPart_smul (r := r) (a := -a)
+
+lemma posPart_smul_of_nonneg {r : ℝ} (hr : 0 ≤ r) {a : A} : (r • a)⁺ = r • a⁺ :=
+  posPart_smul (r := ⟨r, hr⟩)
+
+lemma posPart_smul_of_nonpos {r : ℝ} (hr : r ≤ 0) {a : A} : (r • a)⁺ = -r • a⁻ := by
+  nth_rw 1 [← neg_neg r]
+  rw [neg_smul, ← smul_neg, posPart_smul_of_nonneg (neg_nonneg.mpr hr), posPart_neg]
+
+lemma negPart_smul_of_nonneg {r : ℝ} (hr : 0 ≤ r) {a : A} : (r • a)⁻ = r • a⁻ := by
+  conv_lhs => rw [← neg_neg r, neg_smul, negPart_neg, posPart_smul_of_nonpos (by simpa), neg_neg]
+
+lemma negPart_smul_of_nonpos {r : ℝ} (hr : r ≤ 0) {a : A} : (r • a)⁻ = -r • a⁺ := by
+  conv_lhs => rw [← neg_neg r, neg_smul, negPart_neg, posPart_smul_of_nonneg (by simpa)]
+
+end SMul
+
+variable [PartialOrder A] [StarOrderedRing A]
+
+lemma posPart_eq_of_eq_sub_negPart {a b : A} (hab : a = b - a⁻) (hb : 0 ≤ b := by cfc_tac) :
+    a⁺ = b := by
+  have ha := hab.symm ▸ hb.isSelfAdjoint.sub (negPart_nonneg a).isSelfAdjoint
+  nth_rw 1 [← posPart_sub_negPart a] at hab
+  simpa using hab
+
+lemma negPart_eq_of_eq_PosPart_sub {a c : A} (hac : a = a⁺ - c) (hc : 0 ≤ c := by cfc_tac) :
+    a⁻ = c := by
+  have ha := hac.symm ▸ (posPart_nonneg a).isSelfAdjoint.sub hc.isSelfAdjoint
+  nth_rw 1 [← posPart_sub_negPart a] at hac
+  simpa using hac
+
+lemma le_posPart {a : A} (ha : IsSelfAdjoint a) : a ≤ a⁺ := by
+  simpa [posPart_sub_negPart a] using sub_le_self a⁺ (negPart_nonneg a)
+
+lemma neg_negPart_le {a : A} (ha : IsSelfAdjoint a) : -a⁻ ≤ a := by
+  simpa only [posPart_sub_negPart a, ← sub_eq_add_neg]
+    using le_add_of_nonneg_left (a := -a⁻) (posPart_nonneg a)
+
+variable [NonnegSpectrumClass ℝ A]
+
+lemma posPart_eq_self (a : A) : a⁺ = a ↔ 0 ≤ a := by
+  refine ⟨fun ha ↦ ha ▸ posPart_nonneg a, fun ha ↦ ?_⟩
+  conv_rhs => rw [← cfcₙ_id ℝ a]
+  rw [posPart_def]
+  refine cfcₙ_congr (fun x hx ↦ ?_)
+  simpa [_root_.posPart_def] using quasispectrum_nonneg_of_nonneg a ha x hx
+
+lemma negPart_eq_neg (a : A) : a⁻ = -a ↔ a ≤ 0 := by
+  rw [← neg_inj, neg_neg, eq_comm]
+  refine ⟨fun ha ↦ by rw [ha, neg_nonpos]; exact negPart_nonneg a, fun ha ↦ ?_⟩
+  rw [← neg_nonneg] at ha
+  rw [negPart_def, ← cfcₙ_neg]
+  have _ : IsSelfAdjoint a := neg_neg a ▸ (IsSelfAdjoint.neg <| .of_nonneg ha)
+  conv_lhs => rw [← cfcₙ_id ℝ a]
+  refine cfcₙ_congr fun x hx ↦ ?_
+  rw [Unitization.quasispectrum_eq_spectrum_inr ℝ, ← neg_neg x, ← Set.mem_neg,
+    spectrum.neg_eq, ← Unitization.inr_neg, ← Unitization.quasispectrum_eq_spectrum_inr ℝ] at hx
+  rw [← neg_eq_iff_eq_neg, eq_comm]
+  simpa using quasispectrum_nonneg_of_nonneg _ ha _ hx
+
+end CFC
+
+end NonUnital
+
+section Unital
+
+namespace CFC
+
+variable {A : Type*} [Ring A] [Algebra ℝ A] [StarRing A] [TopologicalSpace A]
+variable [ContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
+variable [UniqueNonUnitalContinuousFunctionalCalculus ℝ A]
+
+@[simp]
+lemma posPart_one : (1 : A)⁺ = 1 := by
+  rw [CFC.posPart_def, cfcₙ_eq_cfc]
+  simp
+
+@[simp]
+lemma negPart_one : (1 : A)⁻ = 0 := by
+  rw [CFC.negPart_def, cfcₙ_eq_cfc]
+  simp
+
+@[simp]
+lemma posPart_algebraMap (r : ℝ) : (algebraMap ℝ A r)⁺ = algebraMap ℝ A r⁺ := by
+  rw [CFC.posPart_def, cfcₙ_eq_cfc]
+  simp
+
+@[simp]
+lemma negPart_algebraMap (r : ℝ) : (algebraMap ℝ A r)⁻ = algebraMap ℝ A r⁻ := by
+  rw [CFC.negPart_def, cfcₙ_eq_cfc]
+  simp
+
+open NNReal in
+@[simp]
+lemma posPart_algebraMap_nnreal (r : ℝ≥0) : (algebraMap ℝ≥0 A r)⁺ = algebraMap ℝ≥0 A r := by
+  rw [CFC.posPart_def, cfcₙ_eq_cfc, IsScalarTower.algebraMap_apply ℝ≥0 ℝ A]
+  simp
+
+open NNReal in
+@[simp]
+lemma posPart_natCast (n : ℕ) : (n : A)⁺ = n := by
+  rw [← map_natCast (algebraMap ℝ≥0 A), posPart_algebraMap_nnreal]
+
+end CFC
+
+end Unital
+
+
+section SpanNonneg
+
+variable {A : Type*} [NonUnitalRing A] [Module ℂ A] [SMulCommClass ℂ A A] [IsScalarTower ℂ A A]
+variable [StarRing A] [TopologicalSpace A] [StarModule ℂ A]
+variable [NonUnitalContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
+variable [PartialOrder A] [StarOrderedRing A]
+
+open Submodule Complex
+open scoped ComplexStarModule
+
+lemma CStarAlgebra.linear_combination_nonneg (x : A) :
+    ((ℜ x : A)⁺ - (ℜ x : A)⁻) + (I • (ℑ x : A)⁺ - I • (ℑ x : A)⁻) = x := by
+  rw [CFC.posPart_sub_negPart _ (ℜ x).2, ← smul_sub, CFC.posPart_sub_negPart _ (ℑ x).2,
+    realPart_add_I_smul_imaginaryPart x]
+
+/-- A C⋆-algebra is spanned by its nonnegative elements. -/
+lemma CStarAlgebra.span_nonneg : Submodule.span ℂ {a : A | 0 ≤ a} = ⊤ := by
+  refine eq_top_iff.mpr fun x _ => ?_
+  rw [← CStarAlgebra.linear_combination_nonneg x]
+  apply_rules [sub_mem, Submodule.smul_mem, add_mem]
+  all_goals
+    refine subset_span ?_
+    first | apply CFC.negPart_nonneg | apply CFC.posPart_nonneg
+
+end SpanNonneg


### PR DESCRIPTION
This does not include the approximate unit changes in 18506.

It does include `‖a⁺‖ ≤ ‖a‖` and `‖a⁻‖ ≤ ‖a‖` and `max ‖a⁺‖ ‖a⁻‖ = ‖a‖`